### PR TITLE
jvm ve jar yollarını otomatik bulma

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Zemberek NLP kütüphanesini Python 3 ile kullanabilmenizi sağlar.
 
 ## Kullanım
-`libjvmpath` ve `zemberekJarpath` değişkenleri için kendi pathlerinizi yazın. `libjvm.so` dosyasının Windows muadili `jvm.dll`'dir. 
+`libjvmpath` argümanı için kendi yolunuzu yazın. `libjvm.so` dosyasının Windows muadili `jvm.dll`'dir. Bu argümana bir değer verilmez ise `JAVA_HOME` veya `JRE_HOME` ortam değişkenlerine göre otomatik olarak bulunmaya çalışılacaktır. Bu repo ile gelen `zemberek-tum-2.0.jar` dosyasını farklı bir klasöre taşıdıysanız bu yolu da `zemberekJarpath` argümanına atamalısınız.
 `stopwords.words('turkish')` komutu ile Türkçe stopwords kullanmak istiyorsanız, `~/nltk_data/corpora/stopwords/turkish` dosyasının var olduğuna emin olunuz.
 
 ```python

--- a/zemberek_python/main_libs.py
+++ b/zemberek_python/main_libs.py
@@ -4,7 +4,7 @@ import snowballstemmer
 from nltk import download
 from nltk.corpus import stopwords
 import jpype
-
+import os
 
 ## KULLANIMI ##
 ###############
@@ -13,9 +13,43 @@ import jpype
 # 2) Parçalara ayrılmış olan haber cümlenin öğelerine ayrılır
 # 3) Cümlenin öğelerine ayrılmış olan kelimelerin kökleri bulunur bir listeye konulur
 
+
+def _find_libjvm():
+    java_home = os.environ.get('JAVA_HOME', None)
+    jre_home = os.environ.get('JRE_HOME', None)
+    if java_home is not None:
+        return _find_libjvm_in_java_home(java_home)
+    elif JRE_HOME is not None:
+        return _find_libjvm_in_jre_home(jre_home)
+    else:
+        raise ValueError('Either set one of JAVA_HOME and JRE_HOME environment variables, or pass a path value to libjvmpath argument.')
+    
+def _find_libjvm_in_java_home(path):
+    if os.name == 'nt': # windows
+        path = os.path.join(path, 'jre', 'bin', 'server', 'jvm.dll')
+    else:
+        path = os.path.join(path, 'jre', 'lib', 'amd64', 'server', 'libjvm.so')
+    if os.path.exists(path):
+        return path
+    else:
+        raise IOError('Could not find libjvm in {}. Please make sure that you set JAVA_HOME environment variable correctly, or pass a value to libjvmpath argument'.format(path))
+        
+def _find_libjvm_in_jre_home(path):
+    if os.name == 'nt': # windows
+        path = os.path.join(path, 'bin', 'server', 'jvm.dll')
+    else:
+        path = os.path.join(path, 'lib', 'amd64', 'server', 'libjvm.so')
+    if os.path.exists(path):
+        return path
+    else:
+        raise IOError('Could not find libjvm in {}. Please make sure that you set JRE_HOME environment variable correctly, or pass a value to libjvmpath argument'.format(path))
+
 class zemberek_api:
-    def __init__(self,libjvmpath,zemberekJarpath):
-        self.libjvmpath = libjvmpath
+    def __init__(self,libjvmpath=None,zemberekJarpath=os.path.join(os.path.dirname(__file__), 'zemberek-tum-2.0.jar')):
+        if libjvmpath is not None:
+            self.libjvmpath = libjvmpath
+        else:
+            self.libjvmpath = _find_libjvm()
         self.zemberekJarpath = zemberekJarpath
 
     def zemberek(self):

--- a/zemberek_python/main_libs.py
+++ b/zemberek_python/main_libs.py
@@ -19,7 +19,7 @@ def _find_libjvm():
     jre_home = os.environ.get('JRE_HOME', None)
     if java_home is not None:
         return _find_libjvm_in_java_home(java_home)
-    elif JRE_HOME is not None:
+    elif jre_home is not None:
         return _find_libjvm_in_jre_home(jre_home)
     else:
         raise ValueError('Either set one of JAVA_HOME and JRE_HOME environment variables, or pass a path value to libjvmpath argument.')


### PR DESCRIPTION
`libjvmpath` ve `zemberekJarpath` yollarını `JAVA_HOME` veya `JRE_HOME` ortam değişkenlerinden otomatik bulma eklendi, `readme.md`'deki açıklama buna göre değiştirildi.